### PR TITLE
Leaves empty string as a value.

### DIFF
--- a/Sources/Plot/API/Attribute.swift
+++ b/Sources/Plot/API/Attribute.swift
@@ -64,10 +64,10 @@ extension Attribute: NodeConvertible {
 
 extension Attribute: AnyAttribute {
     func render() -> String {
-        guard let value = nonEmptyValue else {
+        guard let nonNilValue = value else {
             return ignoreIfValueIsEmpty ? "" : name
         }
 
-        return "\(name)=\"\(value)\""
+        return "\(name)=\"\(nonNilValue)\""
     }
 }

--- a/Tests/PlotTests/HTMLComponentTests.swift
+++ b/Tests/PlotTests/HTMLComponentTests.swift
@@ -378,7 +378,7 @@ final class HTMLComponentTests: XCTestCase {
         <form action="url.com" method="post">\
         <fieldset>\
         <label>Username\
-        <input type="text" name="username" required autofocus autocomplete="off"/>\
+        <input type="text" name="username" value="" required autofocus autocomplete="off"/>\
         </label>\
         <label class="password-label">Password\
         <input type="password" name="password" class="password-input"/>\
@@ -411,7 +411,7 @@ final class HTMLComponentTests: XCTestCase {
 
     func testImageWithoutDescription() {
         let html = Image("image.png").render()
-        XCTAssertEqual(html, #"<img src="image.png"/>"#)
+        XCTAssertEqual(html, #"<img src="image.png" alt=""/>"#)
     }
 
     func testLinkRelationshipAndTarget() {


### PR DESCRIPTION
## Summary
- Fixes attributes visibility when value is empty string (i.e. `""`). Instead of `<tag attr/>` it's now `<tag attr="">`
When the value is `nil` then the behaviour is previous. I believe it now looks more consisted.

## Changes
- Changed `render()` function on `Attribute`.
- Updates tests to reflect handle new attributes format.

## How to Test
Create any Attribute with valid `name` and empty `value`. And render it. E.g.:
`print(Attribute(name: "name", value: "").render())`
Should now show `name=""` instead of `name`.